### PR TITLE
Import with absolte path

### DIFF
--- a/urltools/__init__.py
+++ b/urltools/__init__.py
@@ -1,3 +1,3 @@
-from urltools import *
+from urltools.urltools import *
 
 __version__ = '0.4.0'


### PR DESCRIPTION
With out this on newer pythons

while

```python
import urltools
```
works no methods actually load and e.g the tests fail when

```
from urltools import parse
```

since there are no methods.

More details here: http://python-notes.curiousefficiency.org/en/latest/python_concepts/import_traps.html